### PR TITLE
Use sudoers.d for kitchen user permissions

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -145,7 +145,7 @@ module Kitchen
         base = <<-eos
           RUN useradd -d /home/#{username} -m -s /bin/bash #{username}
           RUN echo #{username}:#{password} | chpasswd
-          RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+          RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/#{username}
         eos
         custom = ''
         Array(config[:provision_command]).each do |cmd|


### PR DESCRIPTION
Since test-kitchen is used to test chef recipes, it is possible that the sudoers file could be modified or rewritten during a recipe run. This means that the sudo permissions of the kitchen user can be overwritten. If the permission is instead included in a separate file in the /etc/sudoers.d directory, no chef recipe should be able to remove those permissions.