### PR TITLE
Allowing kitchen-docker to name instances and link them.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.gem
 *.rbc
 .bundle

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -214,6 +214,12 @@ module Kitchen
         Array(config[:volume]).each {|volume| cmd << " -v #{volume}"}
         Array(config[:volumes_from]).each {|container| cmd << " --volumes-from #{container}"}
         cmd << " -h #{config[:hostname]}" if config[:hostname]
+        cmd << " --name='#{config[:instancename]}'" if config[:instancename]
+        if config[:linkedinstances]
+          config[:linkedinstances].each do |instance|
+            cmd << " --link=#{instance}"
+          end
+        end
         cmd << " -m #{config[:memory]}" if config[:memory]
         cmd << " -c #{config[:cpu]}" if config[:cpu]
         cmd << " -privileged" if config[:privileged]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -214,9 +214,9 @@ module Kitchen
         Array(config[:volume]).each {|volume| cmd << " -v #{volume}"}
         Array(config[:volumes_from]).each {|container| cmd << " --volumes-from #{container}"}
         cmd << " -h #{config[:hostname]}" if config[:hostname]
-        cmd << " --name='#{config[:instancename]}'" if config[:instancename]
-        if config[:linkedinstances]
-          config[:linkedinstances].each do |instance|
+        cmd << " --name='#{config[:instance_name]}'" if config[:instance_name]
+        if config[:linked_instances]
+          config[:linked_instances].each do |instance|
             cmd << " --link=#{instance}"
           end
         end


### PR DESCRIPTION
We needed a way to replicate our slave/master system, and wanted to continue using kitchen.