### PR TITLE
Fix deprecated -dns argument. Add host support

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -210,7 +210,8 @@ module Kitchen
       def build_run_command(image_id)
         cmd = "run -d -p 22"
         Array(config[:forward]).each {|port| cmd << " -p #{port}"}
-        Array(config[:dns]).each {|dns| cmd << " -dns #{dns}"}
+        Array(config[:dns]).each {|dns| cmd << " --dns #{dns}"}
+        Array(config[:add_host]).each {|host, ip| cmd << " --add-host=#{host}:#{ip}"}
         Array(config[:volume]).each {|volume| cmd << " -v #{volume}"}
         Array(config[:volumes_from]).each {|container| cmd << " --volumes-from #{container}"}
         cmd << " -h #{config[:hostname]}" if config[:hostname]


### PR DESCRIPTION
.kitchen.yml example:
```
driver:
  name: docker
  use_sudo: false
  add_host:
    myfakehost1.local: 127.0.0.1
    myfakehost2.local: 127.0.0.2
```