### PR TITLE
Make docker inspect less verbose on the output

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -170,7 +170,7 @@ module Kitchen
           RUN useradd -d /home/#{username} -m -s /bin/bash #{username}
           RUN echo #{username}:#{password} | chpasswd
           RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-          #RUN mkdir -p /etc/sudoers.d
+          RUN mkdir -p /etc/sudoers.d
           RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/#{username}
           RUN chmod 0440 /etc/sudoers.d/#{username}
         eos


### PR DESCRIPTION
For certain command, run the command silently. Still uses docker inspect as the output is used in some places.  Fixes #100 

Ideally, the container_exists method needs to use `docker ps <containerId>` to validate existance.