### PR TITLE
Enable security opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,22 +328,8 @@ Optional parameter.
 Example:
 
 ```
-security_opt: apparmor:my_profile
-```
-
-### cap\_add/cap\_drop
-
-Grant or Deny access to specific Linux Capabilities. This is another way to
-control security of a container, as access can be granted to specific devices
-(e.g. network), or specific operations (e.g. the mounting of filesystems).
-
-Optional parameter. (defaults to unset)
-
-Example:
-
-```
-cap_add: SYS_TIME
-cap_drop: ALL
+security_opt:
+  - apparmor:my_profile
 ```
 
 ## dockerfile

--- a/README.md
+++ b/README.md
@@ -317,6 +317,35 @@ Examples:
   privileged: true
 ```
 
+### security\_opt
+
+Apply a security profile to the Docker container. Allowing finer granularity of
+access control than privileged mode, through leveraging SELinux/AppArmor 
+profiles to grant access to specific resources
+
+Optional parameter.
+
+Example:
+
+```
+security_opt: apparmor:my_profile
+```
+
+### cap\_add/cap\_drop
+
+Grant or Deny access to specific Linux Capabilities. This is another way to
+control security of a container, as access can be granted to specific devices
+(e.g. network), or specific operations (e.g. the mounting of filesystems).
+
+Optional parameter. (defaults to unset)
+
+Example:
+
+```
+cap_add: SYS_TIME
+cap_drop: ALL
+```
+
 ## dockerfile
 
 Use a custom Dockerfile, instead of having Kitchen-Docker build one for you.

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -31,6 +31,9 @@ module Kitchen
       default_config :binary,        'docker'
       default_config :socket,        ENV['DOCKER_HOST'] || 'unix:///var/run/docker.sock'
       default_config :privileged,    false
+      default_config :security_opt,  nil
+      default_config :cap_add,       nil
+      default_config :cap_drop,      nil
       default_config :use_cache,     true
       default_config :remove_images, false
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
@@ -223,6 +226,9 @@ module Kitchen
         cmd << " -m #{config[:memory]}" if config[:memory]
         cmd << " -c #{config[:cpu]}" if config[:cpu]
         cmd << " -privileged" if config[:privileged]
+        cmd << " --security-opt #{config[:security_opt]}" if config[:security_opt]
+        cmd << " --cap-add #{config[:cap_add]}" if config[:cap_add]
+        cmd << " --cap-drop #{config[:cap_drop]}" if config[:cap_drop]
         cmd << " -e http_proxy=#{config[:http_proxy]}" if config[:http_proxy]
         cmd << " -e https_proxy=#{config[:https_proxy]}" if config[:https_proxy]
         cmd << " #{image_id} #{config[:run_command]}"

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -32,8 +32,6 @@ module Kitchen
       default_config :socket,        ENV['DOCKER_HOST'] || 'unix:///var/run/docker.sock'
       default_config :privileged,    false
       default_config :security_opt,  nil
-      default_config :cap_add,       nil
-      default_config :cap_drop,      nil
       default_config :use_cache,     true
       default_config :remove_images, false
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
@@ -226,9 +224,7 @@ module Kitchen
         cmd << " -m #{config[:memory]}" if config[:memory]
         cmd << " -c #{config[:cpu]}" if config[:cpu]
         cmd << " -privileged" if config[:privileged]
-        cmd << " --security-opt #{config[:security_opt]}" if config[:security_opt]
-        cmd << " --cap-add #{config[:cap_add]}" if config[:cap_add]
-        cmd << " --cap-drop #{config[:cap_drop]}" if config[:cap_drop]
+        Array(config[:security_opt]).each { cmd << " --security-opt #{_}" } if config[:security_opt]
         cmd << " -e http_proxy=#{config[:http_proxy]}" if config[:http_proxy]
         cmd << " -e https_proxy=#{config[:https_proxy]}" if config[:https_proxy]
         cmd << " #{image_id} #{config[:run_command]}"


### PR DESCRIPTION
In some cases when testing cookbooks under kitchen-docker, we're needing to run with under privileged mode to run Docker in Docker.
Privileged mode disables the default Docker AppArmor profile. We require the setting of security-opt to apply an appropriate app armor profile.
This change enables that.