### PR TITLE
Add additional config option - provision_docker_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ driver_config:
   require_chef_omnibus: false
 ```
 
+### provision\_docker\_command
+
+Custom Dockerfile command(s) to be run when provisioning the base for the suite containers.
+The difference between this and provision_command is that all provision_command's are prefixed with RUN.
+See https://docs.docker.com/reference/builder/ for potential options.
+
+Examples:
+
+```
+  provision_docker_command:
+    - COPY ./script.sh /tmp/script.sh
+    - RUN /tmp/script.sh
+```
+
+Useful if you have full script's to run that are painful to add/escape in YAML as provision_command's.
+
 ### use\_cache
 
 This determines if the Docker cache is used when provisioning the base for suite

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Examples:
 
 ```
   provision_docker_command:
-    - COPY ./script.sh /tmp/script.sh
+    - COPY script.sh /tmp/script.sh
     - RUN /tmp/script.sh
 ```
 

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -220,7 +220,8 @@ module Kitchen
         # to use things like COPY or ADD in a Dockerfile.
         # To workaround this, write out Dockerfile to a tmp file in the current dir,
         # and remove after running docker.
-        dockerfile_tmp_path = '.Dockerfile-kitchen-tmp'
+        # Needs to be a unique filename, as we may have concurrent test-kitchen runs.
+        dockerfile_tmp_path = ".Dockerfile-kitchen-tmp-#{(0...20).map { ('a'..'z').to_a[rand(26)] }.join}"
         File.open(dockerfile_tmp_path, 'w') { |f| f.write(dockerfile) }
         output = docker_command("#{cmd} -f #{dockerfile_tmp_path} .")
         run_command("rm -f #{dockerfile_tmp_path}", {:quiet => !logger.debug?})

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -182,11 +182,15 @@ module Kitchen
           RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/#{username}
           RUN chmod 0440 /etc/sudoers.d/#{username}
         eos
-        custom = ''
-        Array(config[:provision_command]).each do |cmd|
-          custom << "RUN #{cmd}\n"
+        custom_docker_cmd = ''
+        Array(config[:provision_docker_command]).each do |cmd|
+          custom_docker_cmd << "#{cmd}\n"
         end
-        [from, platform, base, custom].join("\n")
+        custom_cmd = ''
+        Array(config[:provision_command]).each do |cmd|
+          custom_cmd << "RUN #{cmd}\n"
+        end
+        [from, platform, base, custom_docker_cmd, custom_cmd].join("\n")
       end
 
       def dockerfile

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -222,7 +222,6 @@ module Kitchen
         # and remove after running docker.
         dockerfile_tmp_path = '.Dockerfile-kitchen-tmp'
         File.open(dockerfile_tmp_path, 'w') { |f| f.write(dockerfile) }
-        options.delete(:input)
         output = docker_command("#{cmd} -f #{dockerfile_tmp_path} .")
         run_command("rm -f #{dockerfile_tmp_path}", {:quiet => !logger.debug?})
         parse_image_id(output)


### PR DESCRIPTION
Similar to provision_command but you can specify the Dockerfile command prefix for each.

Opted to go this way to avoid breaking provision_command current functionality.

Includes example use case in README.