### PR TITLE
Add support for --devices argument to docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,22 @@ Examples:
   publish_all: true
 ```
 
+### devices
+
+Share a host device with the container.  Host device must be an absolute path.
+
+Examples:
+```
+devices: /dev/vboxdrv
+```
+
+Examples:
+```
+devices:
+  - /dev/vboxdrv
+  - /dev/vboxnetctl
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -233,6 +233,7 @@ module Kitchen
         Array(config[:volume]).each {|volume| cmd << " -v #{volume}"}
         Array(config[:volumes_from]).each {|container| cmd << " --volumes-from #{container}"}
         Array(config[:links]).each {|link| cmd << " --link #{link}"}
+        Array(config[:devices]).each {|device| cmd << " --device #{device}"}
         cmd << " --name #{config[:instance_name]}" if config[:instance_name]
         cmd << " -P" if config[:publish_all]
         cmd << " -h #{config[:hostname]}" if config[:hostname]


### PR DESCRIPTION
This PR adds support for the "--devices" argument, in order to share raw device files with the guest.

My intended purpose is to be able to use VirtualBox inside a test-kitchen environment, and that mostly works. 