### PR TITLE
Docker - Build Context Support

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -218,8 +218,9 @@ module Kitchen
         # To workaround this, write out Dockerfile to a tmp file in the current dir,
         # and remove after running docker.
         # Needs to be a unique filename, as we may have concurrent test-kitchen runs.
-        output = Tempfile.create('Dockerfile-kitchen', Dir.pwd) do |tempf|
+        output = Tempfile.create('Dockerfile-kitchen-', Dir.pwd) do |tempf|
           tempf.write(dockerfile)
+          tempf.rewind
           docker_command("#{cmd} -f #{tempf.path} .")
         end
         parse_image_id(output)

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -218,10 +218,10 @@ module Kitchen
         # To workaround this, write out Dockerfile to a tmp file in the current dir,
         # and remove after running docker.
         # Needs to be a unique filename, as we may have concurrent test-kitchen runs.
-        dockerfile_tmp_path = ".Dockerfile-kitchen-tmp-#{SecureRandom.hex(20)}"
-        File.open(dockerfile_tmp_path, 'w') { |f| f.write(dockerfile) }
-        output = docker_command("#{cmd} -f #{dockerfile_tmp_path} .")
-        File.unlink(dockerfile_tmp_path)
+        output = Tempfile.create('Dockerfile-kitchen', Dir.pwd) do |tempf|
+          tempf.write(dockerfile)
+          docker_command("#{cmd} -f #{tempf.path} .")
+        end
         parse_image_id(output)
       end
 

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -220,7 +220,7 @@ module Kitchen
         # Needs to be a unique filename, as we may have concurrent test-kitchen runs.
         output = Tempfile.create('Dockerfile-kitchen-', Dir.pwd) do |tempf|
           tempf.write(dockerfile)
-          tempf.rewind
+          tempf.close
           docker_command("#{cmd} -f #{tempf.path} .")
         end
         parse_image_id(output)


### PR DESCRIPTION
Adding build context support for docker. creates Dockerfiles's as temp files, instead of sending to docker CLI using stdin. this allows the use of commands like ADD and COPY. See PR https://github.com/portertech/kitchen-docker/pull/133 for discussion.