### PR TITLE
Fix docs for run_command default

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The default value is `false`.
 
 Sets the command used to run the suite container.
 
-The default value is `/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes`.
+The default value is `/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid`.
 
 Examples:
 


### PR DESCRIPTION
This line is split in two with + concatenation in docker.rb, obviously missed.