### PR TITLE
Strip the public_key whitespace

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -201,7 +201,7 @@ module Kitchen
 
         username = config[:username]
         password = config[:password]
-        public_key = IO.read(config[:public_key])
+        public_key = IO.read(config[:public_key]).strip
         homedir = username == 'root' ? '/root' : "/home/#{username}"
 
         base = <<-eos


### PR DESCRIPTION
public_key is not an issue when the key is automatically generated, but it is with user supplied input.

ssh-keygen and a lot of text editors automatically append a newline at the end of the public key string. This breaks the Dockerfile RUN instruction which is essentially generated as:

```
RUN echo 'ssh-rsa key-content
' >> /home/kitchen/.ssh/authorized_keys
```

This is not valid. This small patch tackles this issue.