### PR TITLE
avoiding leaky loopback devices

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -348,8 +348,15 @@ module Kitchen
 
       def rm_container(state)
         container_id = state[:container_id]
-        docker_command("stop #{container_id}")
-        docker_command("rm #{container_id}")
+
+        begin
+          docker_command "exec #{container_id} shutdown now"
+          docker_command "wait #{container_id}" # Wait for shutdown
+        rescue Kitchen::ShellOut::ShellCommandFailed
+          nil
+        end
+        docker_command "stop #{container_id}"
+        docker_command "rm #{container_id}"
       end
 
       def rm_image(state)


### PR DESCRIPTION
I am not sure about this. But you are the ones to decide anyway. :wink: 

@sds claimed in his [article](http://shane.se/blog.html#loose-ends) that there could be leaky loopback devices which could prevented with shutting down the container before.

This PR tries to do this before stopping and removing it traditionally.