### PR TITLE
Add support for Alpine linux platform

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -192,8 +192,8 @@ module Kitchen
           eos
         when 'alpine'
           <<-eos
-            RUN apk --update
-            RUN apk add openssh
+            RUN apk update
+            RUN apk add openssh curl
             RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
           eos

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -190,6 +190,13 @@ module Kitchen
             RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
             RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
           eos
+        when 'alpine'
+          <<-eos
+            RUN apk --update
+            RUN apk add openssh
+            RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
+            RUN ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
+          eos
         when 'arch'
           <<-eos
             RUN pacman -Syu --noconfirm


### PR DESCRIPTION
I wanted to add support for Alpine Linux as it's quite a useful distro with a small footprint around 5MB. This way it will be available as a platform when defining a `platform` in the `.kitchen.yml`

At the moment this fails as Alpine is not a supported platform:

```
# kitchen create sculpin-alpine 
-----> Starting Kitchen (v1.5.0.rc.1)
-----> Creating <sculpin-alpine>...
>>>>>> Create failed on instance <sculpin-alpine>.
>>>>>> Please see .kitchen/logs/sculpin-alpine.log for more details
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Unknown platform 'alpine'
>>>>>> ----------------------
```

This PR is for:
- apk --update
- apk add openssh curl 

*Output within Container*:
https://gist.github.com/timani/03cd67a9a287c0337bdc

Are there some additional tests that would need to be run to make sure it meets the requirements? If so I can gladly add those. 

*Links*
- http://www.alpinelinux.org/
- https://hub.docker.com/_/alpine/