### PR TITLE
set "ENV container docker" for CentOS and friends

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -185,6 +185,7 @@ module Kitchen
           config[:disable_upstart] ? disable_upstart + packages : packages
         when 'rhel', 'centos', 'fedora'
           <<-eos
+            ENV container docker
             RUN yum clean all
             RUN yum install -y sudo openssh-server openssh-clients which curl
             RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''


### PR DESCRIPTION
I was having similar problems to issue #109 where I'm using kitchen-docker to do acceptance testing for puppet modules on centos 7 with systemd. EG after running a puppet module, run serverspec or bats to ensure the module actually installed, configured, and started the service correctly. 

With this patch and the below config, you can get systemd running on the centos7 docker container.

```
driver:
  name: docker
  privileged: true
  provision_command: 
    - /usr/bin/systemctl enable sshd
  run_command: /usr/sbin/init
```

https://developerblog.redhat.com/2014/05/05/running-systemd-within-docker-container/ and https://hub.docker.com/_/centos/ have a bunch of other things you might have to do regarding /sys/fs/cgroup and deleting some systemd "wants" files but I've found I don't have to do that. Someone else's mileage may vary.