### PR TITLE
Don't wait while stopping a container

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -353,7 +353,7 @@ module Kitchen
 
       def rm_container(state)
         container_id = state[:container_id]
-        docker_command("stop #{container_id}")
+        docker_command("stop -t 0 #{container_id}")
         docker_command("rm #{container_id}")
       end
 


### PR DESCRIPTION
Hi,

When the docker container is to be removed, there is a basic timeout of 10s, adding the flag added allow to destroy the container immediately. It allows to gain those 10s between tests.